### PR TITLE
Add missing Arabic and English translations

### DIFF
--- a/src/components/sections/Clients.jsx
+++ b/src/components/sections/Clients.jsx
@@ -13,7 +13,7 @@ const Clients = () => {
             nameKey: 'client1',
             logo: "https://upload.wikimedia.org/wikipedia/ar/1/19/Saudi_Aramco_logo.png",
             alt: "شعار شركة أرامكو السعودية",
-            category: "طاقة",
+            category: t.clients.categoryEnergy,
             projects: "15+"
         },
         {
@@ -21,7 +21,7 @@ const Clients = () => {
             nameKey: 'client2',
             logo: "https://upload.wikimedia.org/wikipedia/commons/f/fc/NBE_logo.png",
             alt: "شعار البنك الأهلي السعودي",
-            category: "بنوك",
+            category: t.clients.categoryBanks,
             projects: "8+"
         },
         {
@@ -29,7 +29,7 @@ const Clients = () => {
             nameKey: 'client3',
             logo: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Logo_of_Sabic.svg/1200px-Logo_of_Sabic.svg.png",
             alt: "شعار شركة سابك",
-            category: "صناعة",
+            category: t.clients.categoryIndustry,
             projects: "12+"
         },
         {
@@ -37,7 +37,7 @@ const Clients = () => {
             nameKey: 'client4',
             logo: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Logo_Ministry_of_Commerce.svg/2560px-Logo_Ministry_of_Commerce.svg.png",
             alt: "شعار وزارة التجارة السعودية",
-            category: "حكومي",
+            category: t.clients.categoryGovernment,
             projects: "6+"
         }
     ];

--- a/src/components/sections/Contact.jsx
+++ b/src/components/sections/Contact.jsx
@@ -75,7 +75,7 @@ const Contact = ({ handleContactSubmit }) => {
         >
           <motion.div variants={fadeInUp} className="inline-flex items-center gap-2 bg-[#b18344]/10 px-4 py-2 rounded-full mb-6">
             <MessageCircle className="w-5 h-5 text-[#b18344]" />
-            <span className="text-[#b18344] font-medium">تواصل معنا</span>
+            <span className="text-[#b18344] font-medium">{t.nav.contact}</span>
           </motion.div>
           
           <motion.h2 variants={fadeInUp} className="text-4xl md:text-5xl font-bold mb-6">

--- a/src/components/sections/Header.jsx
+++ b/src/components/sections/Header.jsx
@@ -261,7 +261,7 @@ const MobileMenu = memo(({ isOpen, onClose, t, activeSection, onNavigate }) => {
                 className="pt-4 space-y-3"
               >
                 <div className="text-sm font-semibold text-[#b18344] mb-3 tracking-wide">
-                  تواصل معنا
+                  {t.nav.contact}
                 </div>
                 <div className="flex items-center gap-4 text-sm text-gray-600 bg-gray-50/80 rounded-xl p-3">
                   <div className="p-2 bg-[#b18344]/10 rounded-lg">

--- a/src/lib/translations.js
+++ b/src/lib/translations.js
@@ -89,6 +89,10 @@ export const translations = {
         trustCert1: "شهادة الجودة",
         trustCert2: "التصنيف الائتماني",
         trustCert3: "الالتزام بالمواعيد",
+        categoryEnergy: "طاقة",
+        categoryBanks: "بنوك",
+        categoryIndustry: "صناعة",
+        categoryGovernment: "حكومي",
     },
     contact: {
         title: "تواصل معنا",
@@ -232,6 +236,10 @@ export const translations = {
         trustCert1: "Quality Certificate",
         trustCert2: "Credit Rating",
         trustCert3: "On-Time Delivery",
+        categoryEnergy: "Energy",
+        categoryBanks: "Banks",
+        categoryIndustry: "Industry",
+        categoryGovernment: "Government",
     },
     contact: {
         title: "Contact Us",


### PR DESCRIPTION
## Summary
- add client category translation keys for Arabic and English
- use translations in Clients section
- translate "Contact Us" labels in header and contact section

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a600c7f50832ab9d2e52526ec0042