### PR TITLE
Redirect feature buttons to contact section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,10 +32,10 @@ function AppContent() {
   };
 
   const handleFeatureClick = () => {
-    toast({
-      title: t.toast.featureTitle,
-      description: t.toast.featureDescription,
-    });
+    const contact = document.getElementById('contact');
+    if (contact) {
+      contact.scrollIntoView({ behavior: 'smooth' });
+    }
   };
 
   return (

--- a/src/components/sections/About.jsx
+++ b/src/components/sections/About.jsx
@@ -113,10 +113,13 @@ const About = () => {
 
         {/* Bottom CTA Section */}
         <div className="text-center mt-16">
-          <div className="inline-flex items-center gap-3 px-8 py-4 bg-gradient-to-r from-[#b18344] to-[#c49454] text-white rounded-full shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300 cursor-pointer group">
+          <a
+            href="#contact"
+            className="inline-flex items-center gap-3 px-8 py-4 bg-gradient-to-r from-[#b18344] to-[#c49454] text-white rounded-full shadow-lg hover:shadow-xl transform hover:scale-105 transition-all duration-300 group"
+          >
             <span className="text-lg font-semibold">{t.about.cta}</span>
             <ChevronRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
-          </div>
+          </a>
         </div>
       </div>
     </section>

--- a/src/components/sections/Hero.jsx
+++ b/src/components/sections/Hero.jsx
@@ -520,7 +520,10 @@ const Hero = ({ handleFeatureClick }) => {
   }, [handleFeatureClick]);
 
   const onWatchDemo = useCallback(() => {
-    console.log('Watch demo clicked');
+    const contact = document.getElementById('contact');
+    if (contact) {
+      contact.scrollIntoView({ behavior: 'smooth' });
+    }
   }, []);
 
   return (

--- a/src/components/sections/Projects.jsx
+++ b/src/components/sections/Projects.jsx
@@ -164,16 +164,17 @@ const Projects = () => {
                     viewport={{ once: true }}
                     className="text-center mt-16"
                 >
-                    <button 
+                    <a
+                        href="#contact"
                         className="inline-flex items-center gap-3 px-8 py-4 rounded-full font-medium text-white transition-all duration-300 transform hover:scale-105 hover:shadow-lg"
-                        style={{ 
+                        style={{
                             background: 'linear-gradient(135deg, #b18344 0%, #d4a574 50%, #b18344 100%)',
                             boxShadow: '0 4px 20px rgba(177, 131, 68, 0.3)'
                         }}
                     >
                         <span>{t.projects.exploreAll}</span>
                         <ExternalLink className="w-5 h-5" />
-                    </button>
+                    </a>
                 </motion.div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- make feature buttons scroll to `#contact`
- update hero demo button to scroll to `#contact`
- change About CTA and Projects button to links pointing at `#contact`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a60c79c08832aa87576c580977838