### PR TITLE
Enhance mobile responsiveness

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,7 @@ body {
   background: linear-gradient(135deg, #FFFFFF 0%, #F8F9FA 100%);
   color: var(--gray-dark);
   line-height: 1.6;
+  overflow-x: hidden;
 }
 
 html[dir="rtl"] body {
@@ -85,6 +86,12 @@ html[dir="ltr"] body {
 @media (max-width: 768px) {
   .section-padding {
     padding: 60px 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .section-padding {
+    padding: 40px 0;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,13 +8,16 @@ module.exports = {
 		'./src/**/*.{js,jsx}',
 	],
 	theme: {
-		container: {
-			center: true,
-			padding: '2rem',
-			screens: {
-				'2xl': '1400px',
-			},
-		},
+                container: {
+                        center: true,
+                        padding: {
+                                DEFAULT: '1rem',
+                                sm: '2rem',
+                        },
+                        screens: {
+                                '2xl': '1400px',
+                        },
+                },
 		extend: {
 			colors: {
 				border: 'hsl(var(--border))',


### PR DESCRIPTION
## Summary
- tweak Tailwind container padding for small screens
- prevent horizontal scrolling on mobile
- refine section padding at 640px breakpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a9163c144832abbc76a7ce376d100