### PR TITLE
Set mobile hero top padding

### DIFF
--- a/src/components/sections/Hero.jsx
+++ b/src/components/sections/Hero.jsx
@@ -356,7 +356,10 @@ const HeroContent = memo(({ t, onFeatureClick, onWatchDemo }) => {
   const [primaryButtonHovered, setPrimaryButtonHovered] = useState(false);
 
   return (
-    <div className="container mx-auto px-6 text-center relative z-10" ref={ref}>
+    <div
+      className="container mx-auto px-6 text-center relative z-10 pt-[7.5rem] sm:pt-0"
+      ref={ref}
+    >
       <motion.div
         variants={contentVariants.container}
         initial="initial"


### PR DESCRIPTION
## Summary
- adjust hero container to add 7.5rem top padding on mobile only

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a952805d0832a9a837d7e51925629