### PR TITLE
Fix unclosed arrow function in Services section

### DIFF
--- a/src/components/sections/Services.jsx
+++ b/src/components/sections/Services.jsx
@@ -59,7 +59,6 @@ const iconContainerVariants = {
 };
 
 // Simplified and improved professional service card component
-const ServiceCard = ({ icon: Icon, title, description, features, onButtonClick }) => {
 // Professional service card component
 const ServiceCard = ({ icon: Icon, title, description, features, isPopular = false, onButtonClick, link }) => {
   const [isHovered, setIsHovered] = useState(false);


### PR DESCRIPTION
## Summary
- remove duplicate ServiceCard function definition

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d054b1630832a90436aeff053d02c