### PR TITLE
Improve icon relevance

### DIFF
--- a/src/components/sections/Footer.jsx
+++ b/src/components/sections/Footer.jsx
@@ -10,9 +10,9 @@ import {
   Instagram, 
   Linkedin,
   ArrowUp,
-  Building2,
-  Users,
-  Briefcase,
+  LayoutDashboard,
+  Mic,
+  CalendarCheck,
   ChevronRight
 } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -40,9 +40,9 @@ const Footer = () => {
   const { t } = useLanguage();
 
   const services = [
-    { icon: Building2, title: t.footer.service1Title, desc: t.footer.service1Desc },
-    { icon: Users, title: t.footer.service2Title, desc: t.footer.service2Desc },
-    { icon: Briefcase, title: t.footer.service3Title, desc: t.footer.service3Desc }
+    { icon: LayoutDashboard, title: t.footer.service1Title, desc: t.footer.service1Desc },
+    { icon: Mic, title: t.footer.service2Title, desc: t.footer.service2Desc },
+    { icon: CalendarCheck, title: t.footer.service3Title, desc: t.footer.service3Desc }
   ];
 
   return (

--- a/src/components/sections/Projects.jsx
+++ b/src/components/sections/Projects.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { fadeInUp, staggerContainer } from '@/lib/animations';
 import { useLanguage } from '@/contexts/LanguageContext';
-import { ExternalLink, Award, Users } from 'lucide-react';
+import { ExternalLink, ShoppingBag, Mic, Award, PartyPopper } from 'lucide-react';
 
 const Projects = () => {
     const { t } = useLanguage();
@@ -14,7 +14,7 @@ const Projects = () => {
             textKey: 'project1Text',
             image: "https://images.unsplash.com/photo-1697134674327-3f2261031064",
             alt: "معرض تجاري كبير بتصميم حديث",
-            icon: Users,
+            icon: ShoppingBag,
             categoryKey: 'categoryTrade'
         },
         {
@@ -23,7 +23,7 @@ const Projects = () => {
             textKey: 'project2Text',
             image: "https://images.unsplash.com/photo-1700936656167-5dc37a6f1e20",
             alt: "مؤتمر علمي في قاعة كبيرة",
-            icon: Award,
+            icon: Mic,
             categoryKey: 'categoryConference'
         },
         {
@@ -32,7 +32,7 @@ const Projects = () => {
             textKey: 'project3Text',
             image: "https://images.unsplash.com/photo-1554123460-3f3501064723",
             alt: "حفل تكريم أنيق بإضاءة ذهبية",
-            icon: ExternalLink,
+            icon: Award,
             categoryKey: 'categoryCeremony'
         },
         {
@@ -41,7 +41,7 @@ const Projects = () => {
             textKey: 'project4Text',
             image: "https://images.unsplash.com/photo-1508672019048-805c876b67e2",
             alt: "مهرجان البُر",
-            icon: Users,
+            icon: PartyPopper,
             categoryKey: 'categoryCeremony'
         }
     ];

--- a/src/components/sections/Services.jsx
+++ b/src/components/sections/Services.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Users, Building, Briefcase, ArrowRight, Star, CheckCircle, Sparkles, Gift, PartyPopper } from 'lucide-react';
+import { CalendarCheck, LayoutTemplate, Ticket, Hammer, Camera, MapPin, ArrowRight, Gift, Droplet, PartyPopper, Sparkles, CheckCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useLanguage } from '@/contexts/LanguageContext';
 
@@ -229,34 +229,34 @@ const Services = ({ handleFeatureClick }) => {
   // Simplified services data without `isPopular`
   const servicesData = [
     {
-      icon: Building,
+      icon: CalendarCheck,
       title: t.services.service1Title,
       description: t.services.service1Text,
     },
     {
-      icon: Users,
+      icon: LayoutTemplate,
       title: t.services.service2Title,
       description: t.services.service2Text,
     },
     {
-      icon: Briefcase,
+      icon: Ticket,
       title: t.services.service3Title,
       description: t.services.service3Text,
     },
     {
-      icon: Star,
+      icon: Hammer,
       title: t.services.service4Title,
       description: t.services.service4Text,
       features: null,
     },
     {
-      icon: CheckCircle,
+      icon: Camera,
       title: t.services.service5Title,
       description: t.services.service5Text,
       features: null,
     },
     {
-      icon: ArrowRight,
+      icon: MapPin,
       title: t.services.service6Title,
       description: t.services.service6Text,
       features: null,
@@ -271,7 +271,7 @@ const Services = ({ handleFeatureClick }) => {
       link: 'https://jzl10.com/'
     },
     {
-      icon: Sparkles,
+      icon: Droplet,
       title: t.services.service8Title,
       description: t.services.service8Text,
       features: null,


### PR DESCRIPTION
## Summary
- switch to more meaningful icons on the Services section
- replace footer service icons with more representative ones
- use better icons for project cards

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1be722d4832a9215139ac30b8308