### PR TITLE
Show only map in contact section

### DIFF
--- a/src/components/sections/Contact.jsx
+++ b/src/components/sections/Contact.jsx
@@ -83,98 +83,25 @@ const Contact = ({ handleContactSubmit }) => {
         </motion.div>
 
         <div className="max-w-6xl mx-auto">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
-            {/* معلومات التواصل */}
-            <motion.div
-              variants={fadeInUp}
-              initial="initial"
-              whileInView="animate"
-              viewport={{ once: true, amount: 0.3 }}
-              className="space-y-8"
-            >
-              <div className="bg-white/80 backdrop-blur-sm p-6 sm:p-8 rounded-3xl shadow-lg border border-white/20 h-full">
-                <h3 className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-3">
-                  <div className="w-8 h-8 bg-gradient-to-r from-[#b18344] to-[#d4a574] rounded-lg flex items-center justify-center">
-                    <MessageCircle className="w-4 h-4 text-white" />
-                  </div>
-                  {t.contact.methodsTitle}
-                </h3>
-                
-                <div className="space-y-6">
-                  {/* ... other contact methods ... */}
-                  <motion.div 
-                    whileHover={{ x: language === 'ar' ? -10 : 10 }}
-                    className="flex items-center gap-4 p-4 rounded-2xl bg-gradient-to-r from-green-50 to-green-100 border border-green-200/50"
-                  >
-                    <div className="w-14 h-14 bg-gradient-to-r from-green-500 to-green-600 rounded-2xl flex items-center justify-center shadow-lg flex-shrink-0">
-                      <MessageCircle className="w-7 h-7 text-white" />
-                    </div>
-                    <div className="flex-1">
-                      <h4 className="text-lg font-semibold text-gray-800">{t.contact.whatsapp}</h4>
-                      <p className="text-gray-600 text-sm">{t.contact.whatsappDescription}</p>
-                      <p className="text-green-600 font-medium text-sm" dir="ltr">{whatsappNumber}</p>
-                    </div>
-                    <Button
-                      onClick={handleDirectWhatsApp}
-                      className="bg-gradient-to-r from-green-500 to-green-600 hover:from-green-600 hover:to-green-700 text-white px-4 sm:px-6 py-2 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
-                    >
-                      <span className="hidden sm:inline">{t.contact.chatButton}</span>
-                      <MessageCircle className="w-4 h-4 sm:hidden" />
-                    </Button>
-                  </motion.div>
-
-                  <motion.div 
-                     whileHover={{ x: language === 'ar' ? -10 : 10 }}
-                    className="flex items-center gap-4 p-4 rounded-2xl bg-gradient-to-r from-[#b18344]/10 to-[#d4a574]/10 border border-[#b18344]/20"
-                  >
-                    <div className="w-14 h-14 bg-gradient-to-r from-[#b18344] to-[#d4a574] rounded-2xl flex items-center justify-center shadow-lg flex-shrink-0">
-                      <Phone className="w-7 h-7 text-white" />
-                    </div>
-                    <div>
-                      <h4 className="text-lg font-semibold text-gray-800">{t.contact.phone}</h4>
-                      <p className="text-gray-600 text-sm">{t.contact.phoneSub}</p>
-                      <p className="text-[#b18344] font-medium" dir="ltr">0504447148</p>
-                    </div>
-                  </motion.div>
-
-                  <motion.div 
-                     whileHover={{ x: language === 'ar' ? -10 : 10 }}
-                    className="flex items-center gap-4 p-4 rounded-2xl bg-gradient-to-r from-blue-50 to-blue-100 border border-blue-200/50"
-                  >
-                    <div className="w-14 h-14 bg-gradient-to-r from-blue-500 to-blue-600 rounded-2xl flex items-center justify-center shadow-lg flex-shrink-0">
-                      <MapPin className="w-7 h-7 text-white" />
-                    </div>
-                    <div>
-                      <h4 className="text-lg font-semibold text-gray-800">{t.contact.address}</h4>
-                      <p className="text-gray-600 text-sm">{t.contact.addressSub}</p>
-                      <p className="text-blue-600 font-medium">{t.contact.addressValue}</p>
-                    </div>
-                  </motion.div>
-                </div>
-              </div>
-            </motion.div>
-
-            {/* خريطة الموقع */}
-            <motion.div
-              variants={fadeInUp}
-              initial="initial"
-              whileInView="animate"
-              viewport={{ once: true, amount: 0.2 }}
-            >
-              <div className="rounded-3xl overflow-hidden shadow-xl border border-gray-200/50 h-full">
-                <iframe
-                  src="https://www.google.com/maps?q=8133+%D8%A7%D9%84%D9%82%D8%AF%D9%8A%D8%AD+-+%D8%AD%D9%8A+%D8%A7%D9%84%D9%86%D8%AF%D9%89+%D8%AD%D9%8A+%D8%A7%D9%84%D9%86%D8%AF%D9%89,+%D8%A7%D9%84%D8%B1%D9%8A%D8%A7%D8%B6+RADA8133,+%D8%A7%D9%84%D9%85%D9%85%D9%84%D9%83%D8%A9+%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9+%D8%A7%D9%84%D8%B3%D8%B9%D9%88%D8%AF%D9%8A%D8%A9&output=embed"
-                  width="100%"
-                  height="450"
-                  style={{ border: 0 }}
-                  allowFullScreen=""
-                  loading="lazy"
-                  referrerPolicy="no-referrer-when-downgrade"
-                  title="موقع شركتنا"
-                ></iframe>
-              </div>
-            </motion.div>
-          </div>
+          <motion.div
+            variants={fadeInUp}
+            initial="initial"
+            whileInView="animate"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            <div className="rounded-3xl overflow-hidden shadow-xl border border-gray-200/50 h-full">
+              <iframe
+                src="https://www.google.com/maps?q=8133+%D8%A7%D9%84%D9%82%D8%AF%D9%8A%D8%AD+-+%D8%AD%D9%8A+%D8%A7%D9%84%D9%86%D8%AF%D9%89+%D8%AD%D9%8A+%D8%A7%D9%84%D9%86%D8%AF%D9%89,+%D8%A7%D9%84%D8%B1%D9%8A%D8%A7%D8%B6+RADA8133,+%D8%A7%D9%84%D9%85%D9%85%D9%84%D9%83%D8%A9+%D8%A7%D9%84%D8%B9%D8%B1%D8%A8%D9%8A%D8%A9+%D8%A7%D9%84%D8%B3%D8%B9%D9%88%D8%AF%D9%8A%D8%A9&output=embed"
+                width="100%"
+                height="450"
+                style={{ border: 0 }}
+                allowFullScreen=""
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
+                title="موقع شركتنا"
+              ></iframe>
+            </div>
+          </motion.div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove WhatsApp and phone info from the contact section
- keep only the embedded map for "Contact Us"

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8b0b39bc832a8113e5a64a73ee15