### PR TITLE
Add basic admin dashboard

### DIFF
--- a/src/admin/AdminApp.jsx
+++ b/src/admin/AdminApp.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import Login from './Login';
+import Dashboard from './Dashboard';
+
+const AdminApp = () => {
+  const [loggedIn, setLoggedIn] = useState(
+    () => localStorage.getItem('adminLoggedIn') === 'true'
+  );
+
+  const handleLogin = (username, password) => {
+    if (username === 'admin' && password === 'admin') {
+      localStorage.setItem('adminLoggedIn', 'true');
+      setLoggedIn(true);
+    } else {
+      alert('Invalid credentials');
+    }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('adminLoggedIn');
+    setLoggedIn(false);
+  };
+
+  return loggedIn ? (
+    <Dashboard onLogout={handleLogout} />
+  ) : (
+    <Login onLogin={handleLogin} />
+  );
+};
+
+export default AdminApp;

--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+const Dashboard = ({ onLogout }) => {
+  const { language, t, updateTranslations } = useLanguage();
+
+  const [contactPhone, setContactPhone] = useState(t.footer.contactPhone);
+  const [contactEmail, setContactEmail] = useState(t.footer.contactEmail);
+  const [contactAddress, setContactAddress] = useState(t.footer.contactAddress);
+
+  const [services, setServices] = useState(
+    Array.from({ length: 9 }, (_, i) => ({
+      title: t.services[`service${i + 1}Title`] || '',
+      text: t.services[`service${i + 1}Text`] || '',
+    }))
+  );
+
+  const [projects, setProjects] = useState(
+    Array.from({ length: 4 }, (_, i) => ({
+      title: t.projects[`project${i + 1}Title`] || '',
+      text: t.projects[`project${i + 1}Text`] || '',
+    }))
+  );
+
+  const handleServiceChange = (index, field, value) => {
+    setServices((prev) => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  };
+
+  const handleProjectChange = (index, field, value) => {
+    setProjects((prev) => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  };
+
+  const handleSave = () => {
+    const serviceUpdates = {};
+    services.forEach((s, idx) => {
+      serviceUpdates[`service${idx + 1}Title`] = s.title;
+      serviceUpdates[`service${idx + 1}Text`] = s.text;
+    });
+    const projectUpdates = {};
+    projects.forEach((p, idx) => {
+      projectUpdates[`project${idx + 1}Title`] = p.title;
+      projectUpdates[`project${idx + 1}Text`] = p.text;
+    });
+
+    updateTranslations(language, {
+      services: serviceUpdates,
+      projects: projectUpdates,
+      footer: {
+        contactPhone,
+        contactEmail,
+        contactAddress,
+      },
+      contact: {
+        addressValue: contactAddress,
+      },
+    });
+    alert('Saved');
+  };
+
+  return (
+    <div className="p-6 space-y-8">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        <button
+          onClick={onLogout}
+          className="bg-red-500 text-white px-4 py-2 rounded"
+        >
+          Logout
+        </button>
+      </div>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Company Info</h2>
+        <input
+          className="border p-2 w-full"
+          value={contactPhone}
+          onChange={(e) => setContactPhone(e.target.value)}
+          placeholder="Phone"
+        />
+        <input
+          className="border p-2 w-full"
+          value={contactEmail}
+          onChange={(e) => setContactEmail(e.target.value)}
+          placeholder="Email"
+        />
+        <input
+          className="border p-2 w-full"
+          value={contactAddress}
+          onChange={(e) => setContactAddress(e.target.value)}
+          placeholder="Address"
+        />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Services</h2>
+        {services.map((service, idx) => (
+          <div key={idx} className="border p-4 rounded space-y-2">
+            <input
+              className="border p-2 w-full"
+              value={service.title}
+              onChange={(e) =>
+                handleServiceChange(idx, 'title', e.target.value)
+              }
+              placeholder={`Service ${idx + 1} Title`}
+            />
+            <textarea
+              className="border p-2 w-full"
+              value={service.text}
+              onChange={(e) =>
+                handleServiceChange(idx, 'text', e.target.value)
+              }
+              placeholder={`Service ${idx + 1} Description`}
+            />
+          </div>
+        ))}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Projects</h2>
+        {projects.map((project, idx) => (
+          <div key={idx} className="border p-4 rounded space-y-2">
+            <input
+              className="border p-2 w-full"
+              value={project.title}
+              onChange={(e) =>
+                handleProjectChange(idx, 'title', e.target.value)
+              }
+              placeholder={`Project ${idx + 1} Title`}
+            />
+            <textarea
+              className="border p-2 w-full"
+              value={project.text}
+              onChange={(e) =>
+                handleProjectChange(idx, 'text', e.target.value)
+              }
+              placeholder={`Project ${idx + 1} Description`}
+            />
+          </div>
+        ))}
+      </section>
+
+      <button
+        onClick={handleSave}
+        className="bg-[#b18344] text-white px-6 py-2 rounded"
+      >
+        Save
+      </button>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/admin/Login.jsx
+++ b/src/admin/Login.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+
+const Login = ({ onLogin }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onLogin(username, password);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-8 rounded shadow-md space-y-4"
+      >
+        <h2 className="text-2xl font-bold text-center">Admin Login</h2>
+        <input
+          className="border p-2 w-64"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          className="border p-2 w-64"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit" className="bg-[#b18344] text-white px-4 py-2 w-full">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/components/sections/Contact.jsx
+++ b/src/components/sections/Contact.jsx
@@ -15,7 +15,7 @@ const Contact = ({ handleContactSubmit }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
 
-  const whatsappNumber = '+966504447148';
+  const whatsappNumber = t.footer.contactPhone || '+966504447148';
 
   const handleInputChange = (e) => {
     setFormData({

--- a/src/components/ui/WhatsAppPopup.jsx
+++ b/src/components/ui/WhatsAppPopup.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { MessageCircle } from 'lucide-react';
 
+import { useLanguage } from '@/contexts/LanguageContext';
+
 const WhatsAppPopup = () => {
-  const whatsappNumber = '9660504447148';
+  const { t } = useLanguage();
+  const whatsappNumber = (t.footer && t.footer.contactPhone) || '9660504447148';
 
   const handleClick = () => {
     window.open(`https://wa.me/${whatsappNumber}`, '_blank');

--- a/src/contexts/LanguageContext.jsx
+++ b/src/contexts/LanguageContext.jsx
@@ -1,21 +1,57 @@
-import React, { createContext, useState, useContext } from 'react';
+import React, { createContext, useState, useContext, useEffect } from 'react';
 import { translations } from '@/lib/translations';
 
 const LanguageContext = createContext();
 
+const loadCustomTranslations = () => {
+  try {
+    return JSON.parse(localStorage.getItem('customTranslations')) || {};
+  } catch {
+    return {};
+  }
+};
+
+const mergeDeep = (target, source) => {
+  if (typeof source !== 'object' || source === null) return source;
+  const output = { ...target };
+  Object.keys(source).forEach((key) => {
+    if (source[key] && typeof source[key] === 'object') {
+      output[key] = mergeDeep(target[key] || {}, source[key]);
+    } else {
+      output[key] = source[key];
+    }
+  });
+  return output;
+};
+
 export const LanguageProvider = ({ children }) => {
   const [language, setLanguage] = useState('ar');
+  const [custom, setCustom] = useState(loadCustomTranslations());
+
+  useEffect(() => {
+    setCustom(loadCustomTranslations());
+  }, []);
+
+  const updateTranslations = (lang, updates) => {
+    const updated = {
+      ...custom,
+      [lang]: mergeDeep(custom[lang] || {}, updates),
+    };
+    setCustom(updated);
+    localStorage.setItem('customTranslations', JSON.stringify(updated));
+  };
+
+  const t = mergeDeep(translations[language], custom[language] || {});
 
   const value = {
     language,
     setLanguage,
-    t: translations[language],
+    t,
+    updateTranslations,
   };
 
   return (
-    <LanguageContext.Provider value={value}>
-      {children}
-    </LanguageContext.Provider>
+    <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>
   );
 };
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from '@/App';
+import AdminApp from '@/admin/AdminApp';
 import '@/index.css';
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+const root = ReactDOM.createRoot(document.getElementById('root'));
+const isAdmin = window.location.pathname.startsWith('/admin');
+
+root.render(
+  <React.StrictMode>{isAdmin ? <AdminApp /> : <App />}</React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- create simple admin dashboard with login and editing
- store custom translations in browser localStorage
- use updated translations across the site
- allow /admin path to load admin interface

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e7c95c94832ab6d7f2a264d6e9bc