### PR TITLE
Fix admin dashboard provider

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from '@/App';
 import AdminApp from '@/admin/AdminApp';
+import { LanguageProvider } from '@/contexts/LanguageContext';
 import '@/index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 const isAdmin = window.location.pathname.startsWith('/admin');
 
 root.render(
-  <React.StrictMode>{isAdmin ? <AdminApp /> : <App />}</React.StrictMode>
+  <React.StrictMode>
+    <LanguageProvider>{isAdmin ? <AdminApp /> : <App />}</LanguageProvider>
+  </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- wrap admin app with `LanguageProvider` so the admin route gets translations

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860eb267d4c832aae2b26e809e2fb13