### PR TITLE
Add dashboard auth settings and side menu

### DIFF
--- a/src/admin/AdminApp.jsx
+++ b/src/admin/AdminApp.jsx
@@ -1,24 +1,31 @@
 import React, { useState } from 'react';
 import Login from './Login';
 import Dashboard from './Dashboard';
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import { Toaster } from '@/components/ui/toaster';
+import { useToast } from '@/components/ui/use-toast';
 
-const AdminApp = () => {
+const AdminAppContent = () => {
+  const { authenticate } = useAuth();
+  const { toast } = useToast();
   const [loggedIn, setLoggedIn] = useState(
     () => localStorage.getItem('adminLoggedIn') === 'true'
   );
 
   const handleLogin = (username, password) => {
-    if (username === 'admin' && password === 'admin') {
+    if (authenticate(username, password)) {
       localStorage.setItem('adminLoggedIn', 'true');
       setLoggedIn(true);
+      toast({ title: 'تم تسجيل الدخول بنجاح' });
     } else {
-      alert('Invalid credentials');
+      toast({ title: 'بيانات الدخول غير صحيحة', variant: 'destructive' });
     }
   };
 
   const handleLogout = () => {
     localStorage.removeItem('adminLoggedIn');
     setLoggedIn(false);
+    toast({ title: 'تم تسجيل الخروج' });
   };
 
   return loggedIn ? (
@@ -27,5 +34,11 @@ const AdminApp = () => {
     <Login onLogin={handleLogin} />
   );
 };
+const AdminApp = () => (
+  <AuthProvider>
+    <AdminAppContent />
+    <Toaster />
+  </AuthProvider>
+);
 
 export default AdminApp;

--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -1,9 +1,14 @@
 import React, { useState } from 'react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { motion } from 'framer-motion';
+import SideMenu from './SideMenu';
+import { useToast } from '@/components/ui/use-toast';
+import { useAuth } from '@/contexts/AuthContext';
 
 const Dashboard = ({ onLogout }) => {
   const { language, t, updateTranslations } = useLanguage();
+  const { credentials, updateCredentials } = useAuth();
+  const { toast } = useToast();
 
   const [contactPhone, setContactPhone] = useState(t.footer.contactPhone);
   const [contactEmail, setContactEmail] = useState(t.footer.contactEmail);
@@ -24,6 +29,10 @@ const Dashboard = ({ onLogout }) => {
       image: t.projects[`project${i + 1}Image`] || '',
     }))
   );
+
+  const [userName, setUserName] = useState(credentials.username);
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
 
   const handleServiceChange = (index, field, value) => {
     setServices((prev) => {
@@ -57,6 +66,17 @@ const Dashboard = ({ onLogout }) => {
     reader.readAsDataURL(file);
   };
 
+  const handleCredentialSave = () => {
+    if (newPassword && newPassword !== confirmPassword) {
+      toast({ title: 'كلمتا المرور غير متطابقتين', variant: 'destructive' });
+      return;
+    }
+    updateCredentials(userName, newPassword || credentials.password);
+    setNewPassword('');
+    setConfirmPassword('');
+    toast({ title: 'تم تحديث بيانات الدخول' });
+  };
+
   const handleSave = () => {
     const serviceUpdates = {};
     services.forEach((s, idx) => {
@@ -83,7 +103,7 @@ const Dashboard = ({ onLogout }) => {
         addressValue: contactAddress,
       },
     });
-    alert('تم الحفظ بنجاح!');
+    toast({ title: 'تم الحفظ بنجاح' });
   };
 
   const sectionVariants = {
@@ -105,18 +125,20 @@ const Dashboard = ({ onLogout }) => {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-50 to-white p-6">
-      <motion.div
-        initial="hidden"
-        animate="visible"
-        variants={{
-          visible: {
-            transition: {
-              staggerChildren: 0.1,
+      <div className="container mx-auto md:flex gap-6">
+        <SideMenu />
+        <motion.div
+          initial="hidden"
+          animate="visible"
+          variants={{
+            visible: {
+              transition: {
+                staggerChildren: 0.1,
+              },
             },
-          },
-        }}
-        className="container mx-auto px-6 py-8 bg-white rounded-3xl shadow-xl border border-gray-200 space-y-10"
-      >
+          }}
+          className="flex-1 px-6 py-8 bg-white rounded-3xl shadow-xl border border-gray-200 space-y-10"
+        >
         <motion.div variants={itemVariants} className="flex justify-between items-center pb-6 border-b border-gray-200">
           <h1
             className="text-3xl font-bold"
@@ -139,7 +161,7 @@ const Dashboard = ({ onLogout }) => {
           </motion.button>
         </motion.div>
 
-        <motion.section variants={sectionVariants} className="space-y-6">
+        <motion.section id="company" variants={sectionVariants} className="space-y-6">
           <h2
             className="text-2xl font-semibold mb-4"
             style={{
@@ -174,7 +196,48 @@ const Dashboard = ({ onLogout }) => {
           />
         </motion.section>
 
-        <motion.section variants={sectionVariants} className="space-y-6">
+        <motion.section id="account" variants={sectionVariants} className="space-y-6">
+          <h2
+            className="text-2xl font-semibold mb-4"
+            style={{
+              background: 'linear-gradient(135deg, #b18344 0%, #d4a574 100%)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              backgroundClip: 'text',
+            }}
+          >
+            بيانات الدخول
+          </h2>
+          <input
+            className="border border-gray-300 p-2 w-full rounded-md focus:outline-none focus:ring-1 focus:ring-[#b18344]"
+            value={userName}
+            onChange={(e) => setUserName(e.target.value)}
+            placeholder="اسم المستخدم"
+          />
+          <input
+            type="password"
+            className="border border-gray-300 p-2 w-full rounded-md focus:outline-none focus:ring-1 focus:ring-[#b18344]"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder="كلمة المرور الجديدة"
+          />
+          <input
+            type="password"
+            className="border border-gray-300 p-2 w-full rounded-md focus:outline-none focus:ring-1 focus:ring-[#b18344]"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="تأكيد كلمة المرور"
+          />
+          <motion.button
+            variants={itemVariants}
+            onClick={handleCredentialSave}
+            className="bg-[#b18344] text-white px-5 py-2 rounded-lg font-semibold shadow-md hover:bg-[#d4a574] transition-colors"
+          >
+            حفظ بيانات الدخول
+          </motion.button>
+        </motion.section>
+
+        <motion.section id="services" variants={sectionVariants} className="space-y-6">
           <h2
             className="text-2xl font-semibold mb-4"
             style={{
@@ -233,7 +296,7 @@ const Dashboard = ({ onLogout }) => {
           </div>
         </motion.section>
 
-        <motion.section variants={sectionVariants} className="space-y-6">
+        <motion.section id="projects" variants={sectionVariants} className="space-y-6">
           <h2
             className="text-2xl font-semibold mb-4"
             style={{
@@ -303,6 +366,7 @@ const Dashboard = ({ onLogout }) => {
         </motion.button>
       </motion.div>
     </div>
+  </div>
   );
 };
 

--- a/src/admin/SideMenu.jsx
+++ b/src/admin/SideMenu.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { Menu } from 'lucide-react';
+
+const links = [
+  { href: '#company', label: 'معلومات الشركة' },
+  { href: '#services', label: 'الخدمات' },
+  { href: '#projects', label: 'المشاريع' },
+  { href: '#account', label: 'بيانات الدخول' },
+];
+
+const SideMenu = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="md:w-48 mb-6 md:mb-0">
+      <button
+        className="md:hidden mb-4 flex items-center justify-center rounded border p-2"
+        onClick={() => setOpen(!open)}
+      >
+        <Menu className="h-6 w-6" />
+      </button>
+      <nav
+        className={`bg-white border rounded-lg shadow-md p-4 space-y-2 md:block ${
+          open ? 'block' : 'hidden'
+        }`}
+      >
+        {links.map((l) => (
+          <a
+            key={l.href}
+            href={l.href}
+            className="block text-sm py-2 px-3 rounded hover:bg-gray-100"
+            onClick={() => setOpen(false)}
+          >
+            {l.label}
+          </a>
+        ))}
+      </nav>
+    </div>
+  );
+};
+
+export default SideMenu;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const DEFAULT_CREDS = { username: 'admin', password: 'admin' };
+const STORAGE_KEY = 'adminCredentials';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [credentials, setCredentials] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFAULT_CREDS;
+    } catch {
+      return DEFAULT_CREDS;
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(credentials));
+  }, [credentials]);
+
+  const updateCredentials = (username, password) => {
+    setCredentials({ username, password });
+  };
+
+  const authenticate = (username, password) =>
+    username === credentials.username && password === credentials.password;
+
+  return (
+    <AuthContext.Provider value={{ credentials, updateCredentials, authenticate }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- introduce `AuthContext` to manage admin credentials
- enhance `AdminApp` with toast messages and use new auth context
- add responsive side menu for dashboard sections
- allow changing login credentials in dashboard
- show toast notifications for save actions

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6860f31fd0e4832aa9f48e8e23e00e71