### PR TITLE
Add persistent API server

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,0 +1,4 @@
+{
+  "customTranslations": {},
+  "credentials": { "username": "admin", "password": "admin" }
+}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"dev": "vite",
-		"build": "node tools/generate-llms.js || true && vite build",
-		"preview": "vite preview"
+        "dev": "concurrently \"node server.js\" \"vite\"",
+        "build": "node tools/generate-llms.js || true && vite build",
+        "preview": "vite preview"
 	},
 	"dependencies": {
 		"@radix-ui/react-alert-dialog": "^1.0.5",
@@ -43,7 +43,8 @@
 		"eslint-config-react-app": "^7.0.1",
 		"postcss": "^8.4.31",
 		"tailwindcss": "^3.3.3",
-		"terser": "^5.39.0",
-		"vite": "^4.5.14"
+        "terser": "^5.39.0",
+        "vite": "^4.5.14",
+        "concurrently": "^8.2.0"
 	}
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,85 @@
+import { createServer } from 'http';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_FILE = join(__dirname, 'data.json');
+
+function loadData() {
+  if (existsSync(DATA_FILE)) {
+    try {
+      return JSON.parse(readFileSync(DATA_FILE, 'utf8'));
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function saveData(data) {
+  writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+function sendJSON(res, data, status = 200) {
+  res.writeHead(status, { 'Content-Type': 'application/json',
+                          'Access-Control-Allow-Origin': '*',
+                          'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+                          'Access-Control-Allow-Headers': 'Content-Type' });
+  res.end(JSON.stringify(data));
+}
+
+function handleBody(req, callback) {
+  let body = '';
+  req.on('data', chunk => { body += chunk; });
+  req.on('end', () => {
+    try {
+      const json = body ? JSON.parse(body) : {};
+      callback(json);
+    } catch {
+      callback({});
+    }
+  });
+}
+
+const server = createServer((req, res) => {
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    });
+    res.end();
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/api/data') {
+    sendJSON(res, loadData());
+  } else if (req.method === 'POST' && req.url === '/api/translations') {
+    handleBody(req, ({ lang, updates }) => {
+      const data = loadData();
+      if (!data.customTranslations) data.customTranslations = {};
+      data.customTranslations[lang] = {
+        ...(data.customTranslations[lang] || {}),
+        ...updates,
+      };
+      saveData(data);
+      sendJSON(res, { status: 'ok' });
+    });
+  } else if (req.method === 'POST' && req.url === '/api/credentials') {
+    handleBody(req, ({ username, password }) => {
+      const data = loadData();
+      data.credentials = { username, password };
+      saveData(data);
+      sendJSON(res, { status: 'ok' });
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`API server running on http://localhost:${PORT}`);
+});

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,25 +1,27 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
 const DEFAULT_CREDS = { username: 'admin', password: 'admin' };
-const STORAGE_KEY = 'adminCredentials';
-
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
-  const [credentials, setCredentials] = useState(() => {
-    try {
-      return JSON.parse(localStorage.getItem(STORAGE_KEY)) || DEFAULT_CREDS;
-    } catch {
-      return DEFAULT_CREDS;
-    }
-  });
+  const [credentials, setCredentials] = useState(DEFAULT_CREDS);
 
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(credentials));
-  }, [credentials]);
+    fetch('/api/data')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.credentials) setCredentials(data.credentials);
+      })
+      .catch(() => {});
+  }, []);
 
   const updateCredentials = (username, password) => {
     setCredentials({ username, password });
+    fetch('/api/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    }).catch(() => {});
   };
 
   const authenticate = (username, password) =>

--- a/vite.config.js
+++ b/vite.config.js
@@ -197,13 +197,16 @@ export default defineConfig({
 		react(),
 		addTransformIndexHtml
 	],
-	server: {
-		cors: true,
-		headers: {
-			'Cross-Origin-Embedder-Policy': 'credentialless',
-		},
-		allowedHosts: true,
-	},
+        server: {
+                cors: true,
+                headers: {
+                        'Cross-Origin-Embedder-Policy': 'credentialless',
+                },
+                allowedHosts: true,
+                proxy: {
+                        '/api': 'http://localhost:3001'
+                }
+        },
 	resolve: {
 		extensions: ['.jsx', '.js', '.tsx', '.ts', '.json', ],
 		alias: {


### PR DESCRIPTION
## Summary
- add an API server that stores credentials and translations to `data.json`
- persist admin credentials/changes through new fetch calls
- fetch custom translations via the API
- proxy `/api` calls from Vite dev server
- run API server and Vite together using `concurrently`

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f9c41c80832ab0d95f8ce69acbf6