### PR TITLE
Fix server functions and static routing

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,28 +1,86 @@
 import { createServer } from 'http';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { dirname, join, resolve } from 'path'; // أضف resolve
+import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_FILE = join(__dirname, 'data.json');
-const BUILD_DIR = resolve(__dirname, 'dist'); // افترض أن ملفات البناء في مجلد dist
+const BUILD_DIR = resolve(__dirname, 'dist');
 
-// ... (بقية دوال loadData, saveData, sendJSON, handleBody)
+function loadData() {
+  if (existsSync(DATA_FILE)) {
+    try {
+      return JSON.parse(readFileSync(DATA_FILE, 'utf8'));
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function saveData(data) {
+  writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+function sendJSON(res, data, status = 200) {
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
+  res.end(JSON.stringify(data));
+}
+
+function handleBody(req, callback) {
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    try {
+      const json = body ? JSON.parse(body) : {};
+      callback(json);
+    } catch {
+      callback({});
+    }
+  });
+}
 
 const server = createServer((req, res) => {
-  // ... (معالجة OPTIONS)
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    });
+    res.end();
+    return;
+  }
 
   if (req.method === 'GET' && req.url === '/api/data') {
     sendJSON(res, loadData());
   } else if (req.method === 'POST' && req.url === '/api/translations') {
-    // ... (معالجة api/translations)
+    handleBody(req, ({ lang, updates }) => {
+      const data = loadData();
+      if (!data.customTranslations) data.customTranslations = {};
+      data.customTranslations[lang] = {
+        ...(data.customTranslations[lang] || {}),
+        ...updates,
+      };
+      saveData(data);
+      sendJSON(res, { status: 'ok' });
+    });
   } else if (req.method === 'POST' && req.url === '/api/credentials') {
-    // ... (معالجة api/credentials)
+    handleBody(req, ({ username, password }) => {
+      const data = loadData();
+      data.credentials = { username, password };
+      saveData(data);
+      sendJSON(res, { status: 'ok' });
+    });
   } else if (req.method === 'GET') {
-    // محاولة خدمة الملفات الثابتة (مثل CSS, JS, صور)
-    const filePath = join(BUILD_DIR, req.url === '/' ? 'index.html' : req.url); // For / or other assets
-    
-    // إذا كان المسار يشير إلى ملف، قم بخدمته
+    const filePath = join(BUILD_DIR, req.url === '/' ? 'index.html' : req.url);
+
     if (existsSync(filePath)) {
       const extname = String(filePath.split('.').pop()).toLowerCase();
       const mimeTypes = {
@@ -33,14 +91,12 @@ const server = createServer((req, res) => {
         jpg: 'image/jpg',
         gif: 'image/gif',
         svg: 'image/svg+xml',
-        // أضف المزيد من الأنواع حسب الحاجة
       };
       const contentType = mimeTypes[extname] || 'application/octet-stream';
 
       res.writeHead(200, { 'Content-Type': contentType });
       res.end(readFileSync(filePath));
     } else {
-      // إذا لم يكن ملفًا ثابتًا، أعد index.html لتوجيه العميل
       const indexFilePath = join(BUILD_DIR, 'index.html');
       if (existsSync(indexFilePath)) {
         res.writeHead(200, { 'Content-Type': 'text/html' });


### PR DESCRIPTION
## Summary
- restore API helper functions in `server.js`
- serve static files when path is not an API route

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617a0f8cb4832a81037fd7726a6928