### PR TITLE
Fix lucide-react icon import

### DIFF
--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -11,7 +11,7 @@ import {
   EyeOff, 
   Settings, 
   Building2, 
-  ServiceIcon as Wrench,
+  Wrench,
   FolderOpen,
   User,
   Shield,


### PR DESCRIPTION
## Summary
- fix lucide-react import for the Wrench icon

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688621496ec8832a84c5cc504771a21a