### PR TITLE
Ensure admin updates persist across devices

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,6 +28,8 @@ function sendJSON(res, data, status = 200) {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
+    // Ensure API responses are never cached so updates are immediately visible
+    'Cache-Control': 'no-store',
   });
   res.end(JSON.stringify(data));
 }

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -7,7 +7,7 @@ export const AuthProvider = ({ children }) => {
   const [credentials, setCredentials] = useState(DEFAULT_CREDS);
 
   useEffect(() => {
-    fetch('/api/data')
+    fetch('/api/data', { cache: 'no-store' })
       .then((res) => res.json())
       .then((data) => {
         if (data.credentials) setCredentials(data.credentials);
@@ -15,13 +15,18 @@ export const AuthProvider = ({ children }) => {
       .catch(() => {});
   }, []);
 
-  const updateCredentials = (username, password) => {
+  const updateCredentials = async (username, password) => {
     setCredentials({ username, password });
-    fetch('/api/credentials', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password }),
-    }).catch(() => {});
+    try {
+      await fetch('/api/credentials', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+        cache: 'no-store',
+      });
+    } catch {
+      // Ignore network errors; state already updated locally
+    }
   };
 
   const authenticate = (username, password) =>


### PR DESCRIPTION
## Summary
- prevent API responses from being cached by adding `Cache-Control: no-store`
- always fetch latest translations/credentials and await save requests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689248415d3c832aabb1bb1fb427100f