### PR TITLE
Upload images to server and preview

### DIFF
--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -311,10 +311,27 @@ const Dashboard = ({ onLogout }) => {
 
   const handleImageUpload = (callback) => (file) => {
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = (e) => callback(e.target.result);
-    reader.readAsDataURL(file);
     markAsChanged();
+    const reader = new FileReader();
+    reader.onload = async (e) => {
+      const imageData = e.target.result;
+      try {
+        const res = await fetch('/api/upload-image', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fileName: file.name, imageData }),
+        });
+        const data = await res.json();
+        if (data.url) {
+          callback(data.url);
+          return;
+        }
+      } catch {
+        // If upload fails, fall back to local preview
+      }
+      callback(imageData);
+    };
+    reader.readAsDataURL(file);
   };
 
   const handleCredentialSave = () => {


### PR DESCRIPTION
## Summary
- Upload selected files to `/api/upload-image` before saving, then store returned URL.
- Fall back to local preview if upload fails.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899a63e68ec832a986590f59488b732