### PR TITLE
Use translation updater in admin save

### DIFF
--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -493,9 +493,9 @@ const Dashboard = ({ onLogout }) => {
         updatedData[language].header = sectionsContent.header;
       }
 
-      // حفظ البيانات مع دمجها مع البيانات الموجودة
+      // حفظ البيانات مع تحديث الحالة المحلية وترحيلها إلى Firebase
       console.log('البيانات المراد حفظها:', updatedData);
-      await firebaseService.saveWebsiteData(updatedData);
+      await updateTranslations(language, updatedData[language]);
       console.log('تم الحفظ بنجاح');
 
       setHasUnsavedChanges(false);


### PR DESCRIPTION
## Summary
- Delegate saving admin dashboard data to the shared `updateTranslations` helper so Firebase and local state stay in sync.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e02ffcb54832aafcb916482bd1b43