### PR TITLE
feat: replace concurrently with dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"dev": "concurrently \"node server.js\" \"vite\"",
+                "dev": "node tools/dev.js",
 		"build": "node tools/generate-llms.js || true && vite build",
 		"preview": "vite preview"
 	},

--- a/tools/dev.js
+++ b/tools/dev.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+
+const vitePath = new URL('../node_modules/vite/bin/vite.js', import.meta.url).pathname;
+
+const processes = [
+  spawn(process.execPath, ['server.js'], { stdio: 'inherit' }),
+  spawn(process.execPath, [vitePath], { stdio: 'inherit' })
+];
+
+function shutdown(signal = 'SIGTERM') {
+  processes.forEach(p => {
+    if (!p.killed) {
+      p.kill(signal);
+    }
+  });
+}
+
+processes.forEach(p => {
+  p.on('exit', code => {
+    shutdown();
+    process.exit(code ?? 0);
+  });
+});
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));


### PR DESCRIPTION
## Summary
- run server and vite with a small Node dev script to avoid shell-quote issues on Windows paths
- update dev npm script to use the new tooling

## Testing
- `npm run dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e0d8ce954832a84a90d08e9c5d309