### PR TITLE
fix: resolve vite path correctly on Windows

### DIFF
--- a/tools/dev.js
+++ b/tools/dev.js
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 
 import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
 
-const vitePath = new URL('../node_modules/vite/bin/vite.js', import.meta.url).pathname;
+// Use fileURLToPath to properly decode the file URL on all platforms
+// especially on Windows where pathname encoding can break native paths.
+const vitePath = fileURLToPath(
+  new URL('../node_modules/vite/bin/vite.js', import.meta.url)
+);
 
 const processes = [
   spawn(process.execPath, ['server.js'], { stdio: 'inherit' }),


### PR DESCRIPTION
## Summary
- use `fileURLToPath` to build Vite binary path so Windows paths with spaces or non-ASCII characters resolve correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node tools/dev.js` *(fails: listen EADDRINUSE: address already in use :::3001)*

------
https://chatgpt.com/codex/tasks/task_e_689e165ced3c832abec24f89e6eaf632