### PR TITLE
fix: preserve nested translation fields when editing

### DIFF
--- a/src/lib/translations.js
+++ b/src/lib/translations.js
@@ -443,16 +443,34 @@ export const updateTranslations = async (language, updates) => {
     if (!currentTranslations) {
       await loadTranslations();
     }
-    
-    // تحديث البيانات المحلية
-    currentTranslations[language] = {
-      ...currentTranslations[language],
-      ...updates
+
+    // دمج عميق للبيانات المحلية مع التحديثات لضمان عدم فقدان الحقول غير المعدلة
+    const mergeDeep = (target = {}, source = {}) => {
+      const output = { ...target };
+      Object.keys(source).forEach((key) => {
+        if (
+          source[key] &&
+          typeof source[key] === 'object' &&
+          !Array.isArray(source[key])
+        ) {
+          output[key] = mergeDeep(target[key] || {}, source[key]);
+        } else {
+          output[key] = source[key];
+        }
+      });
+      return output;
     };
-    
-    // حفظ البيانات في Firebase
-    await firebaseService.saveWebsiteData(currentTranslations);
-    
+
+    currentTranslations[language] = mergeDeep(
+      currentTranslations[language] || {},
+      updates
+    );
+
+    // حفظ البيانات المحدثة في Firebase مع دمجها مع البيانات الموجودة
+    await firebaseService.saveWebsiteData({
+      [language]: currentTranslations[language]
+    });
+
     return true;
   } catch (error) {
     console.error('خطأ في تحديث البيانات:', error);


### PR DESCRIPTION
## Summary
- deep merge translation updates to avoid losing existing nested fields
- save only updated language data back to Firebase

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689eb35b1bd8832a82b39e7631ce0f29